### PR TITLE
JsonViewer: Find based on config rules

### DIFF
--- a/JsonViewer/Config.json
+++ b/JsonViewer/Config.json
@@ -1,5 +1,6 @@
 ﻿{
   "treeViewForeground": "DarkGray",
+  "treeViewBackground": "Transparent",
   "treeViewHighlightBrushKey": "PaleGoldenrod",
   "treeViewHighlightTextBrushKey": "Black",
   "treeViewInactiveSelectionHighlightBrushKey": "LightYellow",
@@ -12,7 +13,7 @@
       "valueContains": [ "failure", "failed", "error" ],
       "color": "red",
       "fontSize": 16,
-      "appliesToParents":  true
+      "appliesToParents": true
     },
     {
       "valueContains": [ "success", "succeeded", "passed" ],
@@ -33,7 +34,7 @@
     {
       "keyIs": [ "events" ],
       "expandChildren": 2,
-      "ignoreCase":  false
+      "ignoreCase": false
     },
     {
       "keyContains": [ "account" ],

--- a/JsonViewer/Config.json
+++ b/JsonViewer/Config.json
@@ -32,7 +32,8 @@
     },
     {
       "keyIs": [ "events" ],
-      "expandChildren": 2
+      "expandChildren": 2,
+      "ignoreCase":  false
     },
     {
       "keyContains": [ "account" ],

--- a/JsonViewer/JsonViewer.csproj
+++ b/JsonViewer/JsonViewer.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Commands\PerWindow\ReloadCommand.cs" />
     <Compile Include="Commands\ToggleCommand.cs" />
     <Compile Include="Model\ClipboardManager.cs" />
+    <Compile Include="Model\FindRule.cs" />
     <Compile Include="Model\ConfigRule.cs" />
     <Compile Include="View\FindMatchNavigator.cs" />
     <Compile Include="View\MainWindowToolbar.xaml.cs">

--- a/JsonViewer/Model/Config.cs
+++ b/JsonViewer/Model/Config.cs
@@ -12,6 +12,7 @@
     internal enum ConfigValue
     {
         TreeViewForeground,
+        TreeViewBackground,
         TreeViewHighlightBrushKey,
         TreeViewHighlightTextBrushKey,
         TreeViewInactiveSelectionHighlightBrushKey,
@@ -160,6 +161,8 @@
                 {
                     case ConfigValue.TreeViewForeground:
                         return Colors.DarkGray;
+                    case ConfigValue.TreeViewBackground:
+                        return Colors.Transparent;
                     case ConfigValue.TreeViewHighlightBrushKey:
                         return Colors.Yellow;
                     case ConfigValue.TreeViewHighlightTextBrushKey:
@@ -182,7 +185,7 @@
             }
         }
 
-        public Brush GetHightlightColor(JsonObject obj)
+        public Brush GetForegroundColor(JsonObject obj)
         {
             ConfigRule rule = obj.Rules.FirstOrDefault(x => x.ForegroundBrush != null);
             if (rule != null)
@@ -193,7 +196,18 @@
             return this.GetBrush(ConfigValue.TreeViewForeground);
         }
 
-        internal double GetHighlightFontSize(JsonObject obj)
+        public Brush GetBackgroundColor(JsonObject obj)
+        {
+            ConfigRule rule = obj.Rules.FirstOrDefault(x => x.BackgroundBrush != null);
+            if (rule != null)
+            {
+                return rule.BackgroundBrush;
+            }
+
+            return this.GetBrush(ConfigValue.TreeViewBackground);
+        }
+
+        internal double GetFontSize(JsonObject obj)
         {
             ConfigRule rule = obj.Rules.FirstOrDefault(x => x.FontSize.HasValue);
             if (rule != null)

--- a/JsonViewer/Model/ConfigRule.cs
+++ b/JsonViewer/Model/ConfigRule.cs
@@ -9,25 +9,42 @@
 
     internal class ConfigRule
     {
-        public IList<string> ExactKeys { get; private set; }
+        protected ConfigRule()
+        {
+            ExactKeys = new List<string>();
+            ExactValues = new List<string>();
+            PartialKeys = new List<string>();
+            PartialValues = new List<string>();
+            AppliesToParents = false;
+            ForegroundBrush = null;
+            BackgroundBrush = null;
+            FontSize = null;
+            ExpandChildren = null;
+            WarningMessage = null;
+            IgnoreCase = false;
+        }
 
-        public IList<string> ExactValues { get; private set; }
+        public IList<string> ExactKeys { get; protected set; }
 
-        public IList<string> PartialKeys { get; private set; }
+        public IList<string> ExactValues { get; protected set; }
 
-        public IList<string> PartialValues { get; private set; }
+        public IList<string> PartialKeys { get; protected set; }
 
-        public bool AppliesToParents { get; private set; }
+        public IList<string> PartialValues { get; protected set; }
 
-        public Brush ForegroundBrush { get; private set; }
+        public bool AppliesToParents { get; protected set; }
 
-        public double? FontSize { get; private set; }
+        public Brush ForegroundBrush { get; protected set; }
 
-        public int? ExpandChildren { get; private set; }
+        public Brush BackgroundBrush { get; protected set; }
 
-        public string WarningMessage { get; private set; }
+        public double? FontSize { get; protected set; }
 
-        public bool IgnoreCase { get; private set; }
+        public int? ExpandChildren { get; protected set; }
+
+        public string WarningMessage { get; protected set; }
+
+        public bool IgnoreCase { get; protected set; }
 
         public static IList<ConfigRule> GenerateRules(ArrayList arrayList)
         {
@@ -113,6 +130,13 @@
                 foregroundBrush = new SolidColorBrush(color);
             }
 
+            Brush backgroundBrush = null;
+            if (dict.ContainsKey("background"))
+            {
+                Color color = (Color)ColorConverter.ConvertFromString((string)dict["background"]);
+                backgroundBrush = new SolidColorBrush(color);
+            }
+
             double? fontSize = null;
             if (dict.ContainsKey("fontSize"))
             {
@@ -145,6 +169,7 @@
                 PartialValues = valuePartials,
                 AppliesToParents = appliesToParents,
                 ForegroundBrush = foregroundBrush,
+                BackgroundBrush = backgroundBrush,
                 FontSize = fontSize,
                 ExpandChildren = expandChildren,
                 WarningMessage = warningMessage,

--- a/JsonViewer/Model/FindRule.cs
+++ b/JsonViewer/Model/FindRule.cs
@@ -25,7 +25,6 @@
             PartialValues = values;
             ForegroundBrush = Config.This.GetBrush(ConfigValue.TreeViewSearchResultForeground);
             BackgroundBrush = Config.This.GetBrush(ConfigValue.TreeViewSearchResultBackground);
-            FontSize = 18;
             IgnoreCase = ignoreCase;
             AppliesToParents = appliesToParents;
         }

--- a/JsonViewer/Model/FindRule.cs
+++ b/JsonViewer/Model/FindRule.cs
@@ -1,0 +1,33 @@
+﻿namespace JsonViewer
+{
+    using System.Collections.Generic;
+
+    internal class FindRule : ConfigRule
+    {
+        internal FindRule(string text, bool ignoreCase, bool searchKeys, bool searchValues, bool appliesToParents)
+            : base()
+        {
+            text = ignoreCase ? text.ToLower() : text;
+
+            List<string> keys = new List<string>();
+            if (searchKeys)
+            {
+                keys.Add(text);
+            }
+
+            List<string> values = new List<string>();
+            if (searchValues)
+            {
+                values.Add(text);
+            }
+
+            PartialKeys = keys;
+            PartialValues = values;
+            ForegroundBrush = Config.This.GetBrush(ConfigValue.TreeViewSearchResultForeground);
+            BackgroundBrush = Config.This.GetBrush(ConfigValue.TreeViewSearchResultBackground);
+            FontSize = 18;
+            IgnoreCase = ignoreCase;
+            AppliesToParents = appliesToParents;
+        }
+    }
+}

--- a/JsonViewer/Model/Finder.cs
+++ b/JsonViewer/Model/Finder.cs
@@ -94,8 +94,13 @@
             {
                 if (this.SetValue(ref _text, value, "Text"))
                 {
-                    Properties.Settings.Default.FindText = _text;
-                    Properties.Settings.Default.Save();
+                    _parentWindow.Dispatcher.BeginInvoke(
+                        new Action(() =>
+                        {
+                            Properties.Settings.Default.FindText = value;
+                            Properties.Settings.Default.Save();
+                        }),
+                        DispatcherPriority.Background);
 
                     Update();
                 }
@@ -158,6 +163,7 @@
         {
             FindRule newRule = null;
             List<JsonObject> hits = new List<JsonObject>();
+            List<JsonObject> misses = new List<JsonObject>();
 
             if (_rootObject != null && !string.IsNullOrEmpty(_text))
             {
@@ -170,11 +176,20 @@
 
                 foreach (JsonObject obj in _rootObject.AllChildren)
                 {
-                    if (newRule.Matches(obj))
+                    bool matches = newRule.Matches(obj);
+                    if (matches)
                     {
                         hits.Add(obj);
                     }
+                    else
+                    {
+                        misses.Add(obj);
+                    }
                 }
+            }
+            else if (_rootObject != null)
+            {
+                misses = _rootObject.AllChildren;
             }
 
             if (this.SetValue(ref _hitCount, hits.Count, "HitCount"))
@@ -198,7 +213,16 @@
 
             Func<Guid, SingularAction, Task<bool>> updateAction = new Func<Guid, SingularAction, Task<bool>>(async (actionId, action) =>
             {
-                foreach (JsonObject obj in _rootObject.AllChildren)
+                foreach (JsonObject obj in misses)
+                {
+                    obj.FindRule = null;
+                    if (!await action.YieldAndContinue(actionId))
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (JsonObject obj in hits)
                 {
                     obj.FindRule = newRule;
                     if (!await action.YieldAndContinue(actionId))
@@ -211,49 +235,6 @@
             });
 
             _action.BeginInvoke(DispatcherPriority.Background, updateAction);
-        }
-
-        private void Highlight(JsonObject obj, ref List<JsonObject> hits, ref List<JsonObject> misses)
-        {
-            bool found = false;
-            if (!string.IsNullOrEmpty(_text))
-            {
-                if (_shouldSearchKeys && this.CompareStrings(obj.Key, _text))
-                {
-                    found = true;
-                }
-                else if (obj.HasChildren ? _shouldSearchParentValues : _shouldSearchValues)
-                {
-                    found = this.CompareStrings(obj.ValueString, _text);
-                }
-            }
-
-            if (found)
-            {
-                hits.Add(obj);
-            }
-            else
-            {
-                misses.Add(obj);
-            }
-
-            if (obj.HasChildren)
-            {
-                foreach (JsonObject child in obj.Children)
-                {
-                    this.Highlight(child, ref hits, ref misses);
-                }
-            }
-        }
-
-        private bool CompareStrings(string text, string substring)
-        {
-            if (_shouldIgnoreCase)
-            {
-                return text.ToLower().Contains(substring.ToLower());
-            }
-
-            return text.Contains(substring);
         }
     }
 }

--- a/JsonViewer/Model/JsonObject.cs
+++ b/JsonViewer/Model/JsonObject.cs
@@ -176,10 +176,7 @@
                 FindRule oldRule = _findRule;
                 FindRule newRule = value;
 
-                if (newRule != null && !newRule.Matches(this))
-                {
-                    newRule = null;
-                }
+                Debug.Assert(newRule == null || newRule.Matches(this));
 
                 if (oldRule == null && newRule == null)
                 {
@@ -206,7 +203,7 @@
                     _rules.Add(newRule);
                 }
 
-                this.FirePropertyChanged("FindRule");
+                App.Current.MainWindow.Dispatcher.BeginInvoke(new Action(() => { this.FirePropertyChanged("FindRule"); }), System.Windows.Threading.DispatcherPriority.Background);
             }
         }
 

--- a/JsonViewer/View/TreeViewData.cs
+++ b/JsonViewer/View/TreeViewData.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
+    using System.Linq;
     using System.Windows.Media;
     using JsonViewer.Commands.PerItem;
     using Utilities;
@@ -112,7 +113,7 @@
                     return Config.This.GetBrush(ConfigValue.TreeViewSearchResultForeground);
                 }
 
-                return Config.This.GetHightlightColor(_jsonObject);
+                return Config.This.GetForegroundColor(_jsonObject);
             }
         }
 
@@ -135,7 +136,7 @@
                     return Config.This.GetBrush(ConfigValue.TreeViewSelectedItemParent);
                 }
 
-                return Brushes.Transparent;
+                return Config.This.GetBackgroundColor(_jsonObject);
             }
         }
 
@@ -151,7 +152,7 @@
         {
             get
             {
-                return Config.This.GetHighlightFontSize(_jsonObject);
+                return Config.This.GetFontSize(_jsonObject);
             }
         }
 
@@ -235,6 +236,9 @@
                 case "Children":
                 case "AllChildren":
                     this.FirePropertyChanged("AllChildren");
+                    break;
+                case "FindRule":
+                    this.FirePropertyChanged(new string[] { "TextColor", "FontSize", "BackgroundColor" });
                     break;
                 default:
                     Debug.Assert(false, "Unknown property change");

--- a/JsonViewer/View/TreeViewData.cs
+++ b/JsonViewer/View/TreeViewData.cs
@@ -238,7 +238,7 @@
                     this.FirePropertyChanged("AllChildren");
                     break;
                 case "FindRule":
-                    this.FirePropertyChanged(new string[] { "TextColor", "FontSize", "BackgroundColor" });
+                    this.FirePropertyChanged(new string[] { "TextColor", "BackgroundColor" });
                     break;
                 default:
                     Debug.Assert(false, "Unknown property change");

--- a/Utilities/SingularAction.cs
+++ b/Utilities/SingularAction.cs
@@ -21,7 +21,7 @@ namespace Utilities
             _dispatcher = dispatcher;
         }
 
-        public void BeginInvoke(DispatcherPriority priority, Func<Guid, Task<bool>> func)
+        public void BeginInvoke(DispatcherPriority priority, Func<Guid, SingularAction, Task<bool>> func)
         {
             Guid actionId = Guid.NewGuid();
             _actionId = actionId;
@@ -48,7 +48,7 @@ namespace Utilities
             }
 
             Debug.Assert(_operation == null);
-            DispatcherOperation operation = _dispatcher.BeginInvoke(priority, func, actionId);
+            DispatcherOperation operation = _dispatcher.BeginInvoke(priority, func, actionId, this);
             _operation = operation;
             Debug.Assert(this.IsRunning);
             this.FirePropertyChanged("IsRunning");

--- a/Utilities/SingularAction.cs
+++ b/Utilities/SingularAction.cs
@@ -48,25 +48,30 @@ namespace Utilities
             }
 
             Debug.Assert(_operation == null);
-            _operation = _dispatcher.BeginInvoke(priority, func, actionId);
+            DispatcherOperation operation = _dispatcher.BeginInvoke(priority, func, actionId);
+            _operation = operation;
             Debug.Assert(this.IsRunning);
             this.FirePropertyChanged("IsRunning");
             _operation.Task.ContinueWith(new Action<Task>(
                 (task) =>
                 {
                     Debug.Assert(task.IsCompleted);
-                    Task<bool> subTask = (Task<bool>)_operation.Result;
-                    subTask.ContinueWith(new Action<Task<bool>>(
-                        (boolTask) =>
-                        {
-                            Debug.Assert(boolTask.IsCompleted);
-                            if (!this.IsRunning)
+                    Debug.Assert(operation.Status == DispatcherOperationStatus.Completed || operation.Status == DispatcherOperationStatus.Aborted);
+                    if (operation.Status == DispatcherOperationStatus.Completed)
+                    {
+                        Task<bool> subTask = (Task<bool>)operation.Result;
+                        subTask.ContinueWith(new Action<Task<bool>>(
+                            (boolTask) =>
                             {
-                                _actionId = Guid.Empty;
-                                _operation = null;
-                                _dispatcher.InvokeAsync(() => { this.FirePropertyChanged("IsRunning"); });
-                            }
-                        }));
+                                Debug.Assert(boolTask.IsCompleted);
+                                if (!this.IsRunning && _operation == operation && _actionId == actionId)
+                                {
+                                    _actionId = Guid.Empty;
+                                    _operation = null;
+                                    _dispatcher.InvokeAsync(() => { this.FirePropertyChanged("IsRunning"); });
+                                }
+                            }));
+                    }
                 }));
         }
 


### PR DESCRIPTION
- Fix race condition in SingularAction
- Add ignoreCase option to rules
- Rules can now specify a background color
- SingularAction now passes the given lambda a reference to the given SingularAction
- Find is now managed by a config rule
- JsonObject has a property for FindRule (either null or the current find rule)
- Add FindRule subclass of ConfigRule